### PR TITLE
Pass context instead of nil to safely shutdown server.

### DIFF
--- a/pkg/github/api/request_test.go
+++ b/pkg/github/api/request_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"reflect"
@@ -40,7 +41,7 @@ func Test_request(t *testing.T) {
 			}
 		})
 	}
-	if err := svr.Shutdown(nil); err != nil {
+	if err := svr.Shutdown(context.Background()); err != nil {
 		t.Errorf("error stoping down web server")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Florian Bergmann <fbergmann@suse.de>